### PR TITLE
Update Org json files to setting format

### DIFF
--- a/orgs/beta.json
+++ b/orgs/beta.json
@@ -1,10 +1,10 @@
 {
   "orgName": "Outbound Funds - Beta Test Org",
   "edition": "Developer",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "ChatterEnabled"
-    ]
+  "settings": {
+    "orgPreferenceSettings": {
+      "s1DesktopEnabled": true,
+      "chatterEnabled": true
+    }
   }
 }

--- a/orgs/demo.json
+++ b/orgs/demo.json
@@ -1,10 +1,10 @@
 {
     "orgName": "Outbound Funds - Demo Test Org",
     "edition": "Developer",
-    "orgPreferences": {
-        "enabled": [
-            "S1DesktopEnabled",
-            "ChatterEnabled"
-        ]
+    "settings": {
+        "orgPreferenceSettings": {
+            "s1DesktopEnabled": true,
+            "chatterEnabled": true
+        }
     }
 }

--- a/orgs/dev.json
+++ b/orgs/dev.json
@@ -1,10 +1,10 @@
 {
   "orgName": "Outbound Funds - Dev Org",
   "edition": "Developer",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "ChatterEnabled"
-    ]
+  "settings": {
+    "orgPreferenceSettings": {
+      "s1DesktopEnabled": true,
+      "chatterEnabled": true
+    }
   }
 }

--- a/orgs/feature.json
+++ b/orgs/feature.json
@@ -1,10 +1,10 @@
 {
   "orgName": "Outbound Funds - Feature Test Org",
   "edition": "Developer",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "ChatterEnabled"
-    ]
+  "settings": {
+    "orgPreferenceSettings": {
+      "s1DesktopEnabled": true,
+      "chatterEnabled": true
+    }
   }
 }

--- a/orgs/release.json
+++ b/orgs/release.json
@@ -1,10 +1,10 @@
 {
   "orgName": "Outbound Funds - Release Test Org",
   "edition": "Enterprise",
-  "orgPreferences" : {
-    "enabled": [
-      "S1DesktopEnabled",
-      "ChatterEnabled"
-    ]
+  "settings": {
+    "orgPreferenceSettings": {
+      "s1DesktopEnabled": true,
+      "chatterEnabled": true
+    }
   }
 }


### PR DESCRIPTION
# Critical Changes
Based on Salesforce Winer 19, you can specify scratch org settings or org preferences in your scratch org definition file, but not both. Salesforce encourages to convert org preferences to scratch org settings in your scratch org definition. Scratch org settings provide more settings that aren’t currently available as org preferences.

# Issues Closed
#24 

